### PR TITLE
Add Ctrl+Enter hotkey for non-mac platforms, fixes #5

### DIFF
--- a/src/Panel/repl.html
+++ b/src/Panel/repl.html
@@ -26,7 +26,7 @@ Some features coming with ES6 - uncomment to try them out!
 // console.log( squared(5) );
 
 </textarea>
-<button>Run it (&#8984;&#8617;)</button>
+<button>Run it (<span id="combinationKey">&#8984;</span>&#8617;)</button>
 
 <script type="text/javascript" src="../node_modules/traceur/bin/traceur.js"></script>
 <script type="text/javascript" src="repl.js"></script>

--- a/src/Panel/repl.js
+++ b/src/Panel/repl.js
@@ -25,8 +25,16 @@ document.addEventListener('DOMContentLoaded', function(){
     }
   }
 
+  var combinationKey = 'metaKey';
+  chrome.runtime.sendMessage('platformInfo', function(info) {
+    if (info.os !== 'mac') {
+      combinationKey = 'ctrlKey';
+      document.getElementById('combinationKey').textContent = 'Ctrl';
+    }
+  });
+
   document.onkeydown = function(e){
-    if(e.metaKey && e.which == 13){
+    if(e[combinationKey] && e.which == 13){
       deliverContent(editor.getValue());
     }
   }

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,8 @@
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+  if (request === 'platformInfo') {
+    chrome.runtime.getPlatformInfo(function(info) {
+      sendResponse(info);
+    });
+    return true; // indicates sendResponse will be called asynchronously
+  }
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,6 +11,9 @@
     "storage",
     "tabs"
   ],
+  "background": {
+    "scripts": ["background.js"]
+  },
   "web_accessible_resources": [
     "node_modules/traceur/bin/traceur-runtime.js"
   ]


### PR DESCRIPTION
See #5

This is how the button will look on non-mac platforms:

![](http://i.imgur.com/zmLz96A.png)
