### PR TITLE
Remove needless `.type = 'text/javascript'`

### DIFF
--- a/src/Panel/repl.js
+++ b/src/Panel/repl.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function(){
-  var str = "var st = document.createElement('script'); st.type = 'text/javascript'; st.src = '"+chrome.extension.getURL('node_modules/traceur/bin/traceur-runtime.js')+"'; (document.head||document.documentElement).appendChild(st);"
+  var str = "var st = document.createElement('script'); st.src = '"+chrome.extension.getURL('node_modules/traceur/bin/traceur-runtime.js')+"'; (document.head||document.documentElement).appendChild(st);"
   chrome.devtools.inspectedWindow.eval(str)
 
   var editor = CodeMirror.fromTextArea(document.querySelector("textarea"), {


### PR DESCRIPTION
See https://mathiasbynens.be/notes/async-analytics-snippet#type.
