### PR TITLE
UI: make editor height responsive to DevTools resize, put button above editor, remove default body padding, fixes #9

### DIFF
--- a/src/Panel/repl.css
+++ b/src/Panel/repl.css
@@ -1,6 +1,11 @@
 body {
   background: #002b36;
   font-size: 100%;
+  margin: 0;
+}
+
+.CodeMirror {
+  height: auto;
 }
 
 button {
@@ -9,7 +14,8 @@ button {
   border-radius: 10px;
   border: none;
   color: #fff;
-  position: absolute;
+  position: fixed;
+  z-index: 9000;
   bottom: 20px;
   right: 20px;
   font-size: 14px;

--- a/src/Panel/repl.js
+++ b/src/Panel/repl.js
@@ -11,7 +11,6 @@ document.addEventListener('DOMContentLoaded', function(){
     autoCloseBrackets: true
   });
 
-  editor.setSize(window.innerWidth-20, window.innerHeight - 20);
   editor.setOption('theme', 'solarized dark');
 
   var deliverContent = function(content){


### PR DESCRIPTION
See #9 

This PR includes:
- CodeMirror editor height is now responsive to DevTools resize (`.CodeMirror { height: auto; }` and removed `setSize` call).
- "Run it" button stays above the editor (`z-index`). Changed `absolute` to `fixed` as what you really want is `fixed`, and `absolute` was relying on buggy behavior.
- Removed unnecessary body margin -- the scrollbar looks better attached to the outer border, also provides a bit more of room to the editor.

End result:

![](http://i.imgur.com/AWVucoR.png)
