### PR TITLE
Bump versions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,6 @@
   },
   "web_accessible_resources": [
     "node_modules/traceur/bin/traceur-runtime.js",
-    "node_modules/babel/browser-polyfill.js"
+    "node_modules/babel-core/browser-polyfill.js"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Scratch JS",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Write and execute ES6 within DevTools!",
   "devtools_page": "es6-repl.html",
   "manifest_version": 2,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/richgilbank/Scratch-JS",
   "dependencies": {
-    "babel": "^4.6.6",
+    "babel-core": "^5.6.20",
     "codemirror": "^4.12.0",
     "LiveScript": "https://github.com/gkz/LiveScript/archive/1.3.1.tar.gz",
     "coffee-script": "https://github.com/jashkenas/coffeescript/archive/1.9.0.tar.gz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Scratch-JS",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Write ES6 (and other compile-to-JS languages) and execute it on a page from inside DevTools.",
   "repository": {
     "type": "git",

--- a/panel/repl.html
+++ b/panel/repl.html
@@ -86,7 +86,7 @@
 
   <!-- build:vendor vendor.js -->
   <script src="../node_modules/traceur/bin/traceur.js"></script>
-  <script src="../node_modules/babel/browser.js"></script>
+  <script src="../node_modules/babel-core/browser.js"></script>
   <script src="../node_modules/coffee-script/extras/coffee-script.js"></script>
   <script src="../node_modules/LiveScript/browser/livescript.js"></script>
   <script src="../node_modules/codemirror/lib/codemirror.js"></script>

--- a/panel/scripts/repl.js
+++ b/panel/scripts/repl.js
@@ -205,19 +205,25 @@ Repl.prototype.addEventListeners = function() {
     this.removeWidgets();
   }, this);
 
-  bus.on('transformers:error',function(loc,message){
+  bus.on('transformers:error',function(err){
     var msgEl = document.createElement("div");
     msgEl.className = "line-error";
     var icon = msgEl.appendChild(document.createElement("span"));
     icon.innerHTML = "!";
     icon.className = "line-error-icon";
 
+    var message = "<pre>(" + err.line + ":" + err.column + ") " + err.name + ": ";
+    message += err.message + "\n";
+    message += "|" + this.editor.getLine(err.line) + "\n";
+    message += "|" + xCharacters(err.column, ' ') + "^";
+    message += "</pre>";
+
     var msgInfoEl = document.createElement("div");
     msgInfoEl.className = 'line-error-info';
     msgInfoEl.innerHTML = message;
     msgEl.appendChild(msgInfoEl);
 
-    this.widgets.push(this.editor.addLineWidget(loc.line, msgEl, {coverGutter: false, noHScroll: true}));
+    this.widgets.push(this.editor.addLineWidget(err.line, msgEl, {coverGutter: false, noHScroll: true}));
   }, this);
 }
 

--- a/panel/scripts/repl.js
+++ b/panel/scripts/repl.js
@@ -212,7 +212,7 @@ Repl.prototype.addEventListeners = function() {
     icon.innerHTML = "!";
     icon.className = "line-error-icon";
 
-    var message = "<pre>(" + err.line + ":" + err.column + ") " + err.name + ": ";
+    var message = "<pre>(" + (err.line + 1) + ":" + err.column + ") " + err.name + ": ";
     message += err.message + "\n";
     message += "|" + this.editor.getLine(err.line) + "\n";
     message += "|" + xCharacters(err.column, ' ') + "^";

--- a/panel/scripts/transformers/babel.js
+++ b/panel/scripts/transformers/babel.js
@@ -3,7 +3,7 @@ function Babel() {
 
   this.name = 'Babel (' + this.getVersion() + ')';
   this.handle = 'babel';
-  this.runtimePath = 'node_modules/babel/browser-polyfill.js';
+  this.runtimePath = 'node_modules/babel-core/browser-polyfill.js';
   this.opts = {
     experimental: true
   };
@@ -24,11 +24,12 @@ Babel.prototype.transform = function(input) {
   }
   catch(err) {
     if(err.name === "SyntaxError"){
-      var message = "<pre>" + err.toString() + "</pre>";
       bus.trigger("transformers:error", {
+        name: 'SyntaxError',
+        message: err.message,
         line: err.loc.line - 1,
         column: err.loc.column
-      }, message);
+      });
     }
     else {
       throw err;

--- a/panel/scripts/transformers/coffee.js
+++ b/panel/scripts/transformers/coffee.js
@@ -23,11 +23,12 @@ Coffee.prototype.transform = function(input) {
   }
   catch(err){
     if(err.name === "SyntaxError"){
-      var message = "<pre>" + err.toString() + "</pre>";
       bus.trigger("transformers:error", {
+        name: 'SyntaxError',
+        message: err.message,
         line: err.location.first_line,
         column: err.location.first_column
-      }, message);
+      });
     }
     else{
       throw err;

--- a/panel/scripts/util.js
+++ b/panel/scripts/util.js
@@ -17,3 +17,11 @@ function logError(err) {
 function $(query) {
   return document.querySelectorAll(query)
 }
+
+function xCharacters(number, string) {
+  var buffer = '';
+  for(var i = 0; i < number; i++) {
+    buffer += string;
+  }
+  return buffer;
+}


### PR DESCRIPTION
Bumps Babel to 5.x.x and Scratch to version `v0.0.18`. The Babel changes include a migration to the `babel-core` package, which includes a change to error messages, so I'm updating the SyntaxError handling to be constructed more manually. 
Closes https://github.com/richgilbank/Scratch-JS/issues/53