### PR TITLE
Update some packages and the README

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Rich Gilbank
+Copyright (c) 2015 Rich Gilbank
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,34 +1,39 @@
 ## Scratch JS
 
 ### What is it?
-It's a Chrome DevTools extension ([available here](https://chrome.google.com/webstore/detail/scratch-js/alploljligeomonipppgaahpkenfnfkn)) that allows you to execute ES6/ESNext/ES2015 code in the context of the page you're viewing, as though it were the standard DevTools console.
+It's a Chrome DevTools extension ([available here](https://chrome.google.com/webstore/detail/scratch-js/alploljligeomonipppgaahpkenfnfkn)) that allows you to execute ES2015 code in the context of the page you're viewing, as though it were the standard DevTools console.
 
 [Also available for Opera](https://addons.opera.com/en/extensions/details/es6-repl/?display=en)
 
 ### How do I use it?
-Once you familiarize yourself with some of the concepts and features of ES6, [install](https://chrome.google.com/webstore/detail/scratch-js/alploljligeomonipppgaahpkenfnfkn) the extension. You'll then notice the `Scratch JS` tab inside DevTools (⌘-⌥-i on a Mac, ctrl-⇧-i on a PC). You can toggle console visibility with `esc`, and code can be executed either by clicking the _Run it_ button, or using ⌘-↩ on a Mac, ctrl-↩ on a PC.
+Once you familiarize yourself with some of the concepts and features of ES2015, [install](https://chrome.google.com/webstore/detail/scratch-js/alploljligeomonipppgaahpkenfnfkn) the extension. You'll then notice the `Scratch JS` tab inside DevTools (⌘-⌥-i on a Mac, ctrl-⇧-i on a PC). You can toggle console visibility with `esc`, and code can be executed either by clicking the _Run it_ button, or using ⌘-↩ on a Mac, ctrl-↩ on a PC.
 
 ### How does it work?
-It uses one of two engines to transpile ES6 to good-old-fashioned ES5: Google's [Traceur](https://github.com/google/traceur-compiler) and [babel](https://github.com/babel/babel/). Select which one you want to use from the Settings panel. If there's a feature you want to use that isn't working, check the [compatibility table](http://kangax.github.io/compat-table/es6/) under those 2 columns to see if it's been implemented yet. 
+It uses one of two engines to transpile ES2015 to good-old-fashioned ES5: Google's [Traceur](https://github.com/google/traceur-compiler) and [Babel](https://github.com/babel/babel/). Select which one you want to use from the Settings panel. If there's a feature you want to use that isn't working, check the [compatibility table](http://kangax.github.io/compat-table/es6/) under those 2 columns to see if it's been implemented yet. 
 
 ### But why?
-Both [Traceur](https://google.github.io/traceur-compiler/demo/repl.html#) and [babel](https://babeljs.io/) already have their own REPLs. Why make a Chrome extension? For me it was just the convenience of being able to read a blog about a new feature or syntax and try it right there while I'm reading the article. Pop open the DevTools on the side of the page and give'r.
+Both [Traceur](https://google.github.io/traceur-compiler/demo/repl.html#) and Babel](https://babeljs.io/) already have their own REPLs. Why make a Chrome extension? For me it was just the convenience of being able to read a blog about a new feature or syntax and try it right there while I'm reading the article. Pop open the DevTools on the side of the page and give'r.
 
 ![](https://s3.amazonaws.com/f.cl.ly/items/2b0E2v0L1z2z060j2l0m/scratch2.jpg)
 
 ### Contributing and local development
 To get it running locally, you'll need to clone the repo, install gulp and other project dependencies, then run the gulp task:
-```
+
+```shell
 git clone git@github.com:richgilbank/Scratch-JS.git && cd Scratch-JS
 npm install -g gulp
 npm install
 gulp
 ```
-You'll then need to install it locally in Chrome. Go to the URL `chrome://extensions` and select 'Developer mode', then click 'Load unpacked extension...' and navigate to the `src` directory of the project and open it. 
+
+You'll then need to install it locally in Chrome. Go to the URL `chrome://extensions` and select "Developer mode", then click "Load unpacked extension..." and select the root directory of the project. 
+
 The gulp task will reload the panel every time you make a change to a file in the `panel` directory.
+
 Happy development!
 
 =========================
 
 Traceur is released under an [Apache 2.0 license](https://github.com/google/traceur-compiler/blob/master/LICENSE) and Babel is released under [MIT](https://github.com/babel/babel/blob/master/LICENSE). They belong to their respective owners. 
+
 Everything else here is [MIT](https://github.com/richgilbank/ES6-Repl-Chrome-Extension/blob/master/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 ## Scratch JS
 
 ### What is it?
-It's a Chrome DevTools extension ([available here](https://chrome.google.com/webstore/detail/scratch-js/alploljligeomonipppgaahpkenfnfkn)) that allows you to execute ES2015 code in the context of the page you're viewing, as though it were the standard DevTools console.
+It's a Chrome DevTools extension ([available here](https://chrome.google.com/webstore/detail/scratch-js/alploljligeomonipppgaahpkenfnfkn)) that allows you to execute ES6/ES2015 code in the context of the page you're viewing, as though it were the standard DevTools console.
 
 [Also available for Opera](https://addons.opera.com/en/extensions/details/es6-repl/?display=en)
 
 ### How do I use it?
-Once you familiarize yourself with some of the concepts and features of ES2015, [install](https://chrome.google.com/webstore/detail/scratch-js/alploljligeomonipppgaahpkenfnfkn) the extension. You'll then notice the `Scratch JS` tab inside DevTools (⌘-⌥-i on a Mac, ctrl-⇧-i on a PC). You can toggle console visibility with `esc`, and code can be executed either by clicking the _Run it_ button, or using ⌘-↩ on a Mac, ctrl-↩ on a PC.
+Once you familiarize yourself with some of the concepts and features of ES6/ES2015, [install](https://chrome.google.com/webstore/detail/scratch-js/alploljligeomonipppgaahpkenfnfkn) the extension. You'll then notice the `Scratch JS` tab inside DevTools (⌘-⌥-i on a Mac, ctrl-⇧-i on a PC). You can toggle console visibility with `esc`, and code can be executed either by clicking the _Run it_ button, or using ⌘-↩ on a Mac, ctrl-↩ on a PC.
 
 ### How does it work?
-It uses one of two engines to transpile ES2015 to good-old-fashioned ES5: Google's [Traceur](https://github.com/google/traceur-compiler) and [Babel](https://github.com/babel/babel/). Select which one you want to use from the Settings panel. If there's a feature you want to use that isn't working, check the [compatibility table](http://kangax.github.io/compat-table/es6/) under those 2 columns to see if it's been implemented yet. 
+It uses one of two engines to transpile ES6/ES2015 to good-old-fashioned ES5: Google's [Traceur](https://github.com/google/traceur-compiler) and [Babel](https://github.com/babel/babel/). Select which one you want to use from the Settings panel. If there's a feature you want to use that isn't working, check the [compatibility table](http://kangax.github.io/compat-table/es6/) under those 2 columns to see if it's been implemented yet. 
 
 ### But why?
 Both [Traceur](https://google.github.io/traceur-compiler/demo/repl.html#) and Babel](https://babeljs.io/) already have their own REPLs. Why make a Chrome extension? For me it was just the convenience of being able to read a blog about a new feature or syntax and try it right there while I'm reading the article. Pop open the DevTools on the side of the page and give'r.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Scratch JS",
   "version": "0.0.21",
-  "description": "Write and execute ES6 within DevTools!",
+  "description": "Write and execute ES2015 within DevTools!",
   "devtools_page": "es6-repl.html",
   "manifest_version": 2,
   "icons": {
@@ -14,7 +14,8 @@
     "tabs"
   ],
   "background": {
-    "scripts": ["background.js"]
+    "scripts": ["background.js"],
+    "persistent": false
   },
   "web_accessible_resources": [
     "node_modules/traceur/bin/traceur-runtime.js",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Scratch JS",
   "version": "0.0.21",
-  "description": "Write and execute ES2015 within DevTools!",
+  "description": "Write and execute ES6/ES2015 within DevTools!",
   "devtools_page": "es6-repl.html",
   "manifest_version": 2,
   "icons": {

--- a/package.json
+++ b/package.json
@@ -15,16 +15,16 @@
   "dependencies": {
     "babel-core": "5.8.25",
     "codemirror": "^4.12.0",
-    "LiveScript": "https://github.com/gkz/LiveScript/archive/1.3.1.tar.gz",
     "coffee-script": "https://github.com/jashkenas/coffeescript/archive/1.9.0.tar.gz",
-    "traceur": "0.0.91"
+    "LiveScript": "https://github.com/gkz/LiveScript/archive/1.3.1.tar.gz",
+    "traceur": "0.0.93"
   },
   "devDependencies": {
-    "del": "^1.1.1",
-    "gulp": "^3.8.11",
-    "gulp-usemin": "^0.3.11",
-    "gulp-zip": "^2.0.2",
-    "tiny-lr": "^0.1.5",
-    "gulp-stylus": "~0.2.1"
+    "del": "^2.2.0",
+    "gulp": "^3.9.0",
+    "gulp-stylus": "~2.1.1",
+    "gulp-usemin": "^0.3.16",
+    "gulp-zip": "^3.0.2",
+    "tiny-lr": "^0.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/richgilbank/Scratch-JS",
   "dependencies": {
     "babel-core": "5.8.25",
-    "codemirror": "^4.12.0",
+    "codemirror": "^5.9.0",
     "coffee-script": "https://github.com/jashkenas/coffeescript/archive/1.9.0.tar.gz",
     "LiveScript": "https://github.com/gkz/LiveScript/archive/1.3.1.tar.gz",
     "traceur": "0.0.93"

--- a/panel/scripts/repl.js
+++ b/panel/scripts/repl.js
@@ -147,6 +147,8 @@ Repl.prototype.updateOutput = function() {
 
     var es5 = transformer.transform(input);
     this.output.setValue(es5);
+
+    this.output.refresh();
   } catch(e) {}
 }
 


### PR DESCRIPTION
Updated a few of the dependencies, along with some minor edits to the README:

- Just use "ES2015" since that's the official name
- Capitalize "Babel" everywhere
- Fixed the part in the local dev section where it was referring to a `src` folder instead of just the root of the project