### PR TITLE
Add Support for Vim Mode

### DIFF
--- a/panel/repl.html
+++ b/panel/repl.html
@@ -58,6 +58,12 @@
                 <span>Indent with tabs</span>
               </label>
             </div>
+            <div class="settings__option-container">
+              <label>
+                <input type="checkbox" name="vimMode">
+                <span>Vim mode (Ctrl-j to exit insert mode)</span>
+              </label>
+            </div>
           </div>
         </div>
         <div class="settings-item">
@@ -122,6 +128,7 @@
   <script src="../node_modules/codemirror/addon/hint/javascript-hint.js"></script>
   <script src="../node_modules/codemirror/mode/javascript/javascript.js"></script>
   <script src="../node_modules/codemirror/addon/edit/closebrackets.js"></script>
+  <script src="../node_modules/codemirror/keymap/vim.js"></script>
   <!-- endbuild -->
 
   <!-- build:js repl.js -->

--- a/panel/scripts/repl.js
+++ b/panel/scripts/repl.js
@@ -42,6 +42,9 @@ Repl.prototype.onDomReady = function() {
     matchBrackets: true,
     continueComments: "Enter",
     extraKeys: {
+      "Ctrl-J": (cm) => {
+        this.Vim.exitInsertMode(cm);
+      },
       "Ctrl-Q": "toggleComment",
       "Ctrl-Space": "autocomplete"
     },
@@ -49,8 +52,12 @@ Repl.prototype.onDomReady = function() {
     indentUnit: this.settings.data.tabSize || 2,
     indentWithTabs: this.settings.data.indentWithTabs || false,
     autoCloseBrackets: true,
-    theme: this.settings.data.theme
+    theme: this.settings.data.theme,
+    keyMap: this.settings.data.vimMode ? 'vim' : 'default'
   });
+
+  // Need to dig in to grab Vim
+  this.Vim = document.querySelector('.CodeMirror').CodeMirror.constructor.Vim
 
   chrome.runtime.sendMessage({name: 'platformInfo'}, function(info) {
     if (info.os !== 'mac') {
@@ -233,6 +240,7 @@ Repl.prototype.addEventListeners = function() {
     this.editor.setOption('indentUnit', tabSize);
   });
   bus.on('settings:changed:indentWithTabs', (useTabs) => this.editor.setOption('indentWithTabs', useTabs));
+  bus.on('settings:changed:vimMode', (vimMode) => this.editor.setOption('vimMode', vimMode));
   bus.on('settings:changed:transformer', () => this.updateOutput());
   bus.on('transformers:beforeTransform', () => this.removeWidgets());
 

--- a/panel/scripts/settings.js
+++ b/panel/scripts/settings.js
@@ -9,7 +9,8 @@ function Settings(repl) {
     tabSize: 2,
     indentUnit: 2,
     indentWithTabs: false,
-    theme: 'default'
+    theme: 'default',
+    vimMode: false
   }
 
   document.addEventListener('DOMContentLoaded', this.onDomReady.bind(this));
@@ -78,6 +79,13 @@ Settings.prototype.onDomReady = function() {
     }.bind(this));
   }.bind(this));
 
+  [].forEach.call(document.querySelectorAll('input[name="vimMode"]'), function (el) {
+    el.addEventListener('click', function(e) {
+      var val = document.querySelectorAll('input[name="vimMode"]')[0].checked;
+      this.set({ vimMode: val });
+    }.bind(this));
+  }.bind(this));
+
   // Add the first external source input row
   this.DOM.includedScriptsContainer.insertAdjacentHTML('beforeend', this.newSourceRow());
 
@@ -140,6 +148,7 @@ Settings.prototype.setFormDefaults = function() {
   document.querySelector('[name="theme"][value="' + this.data.theme + '"]').checked = true;
   document.querySelector('[name="tabSize"]').value = this.data.tabSize;
   document.querySelector('[name="indentWithTabs"]').checked = this.data.indentWithTabs;
+  document.querySelector('[name="vimMode"]').checked = this.data.vimMode;
 }
 
 Settings.prototype.loadingOn = function() {


### PR DESCRIPTION
Adds support for Vim mode to CodeMirror. **Note**: due to conflicts between `<Esc>` toggling the DevTools console, I added the keymap `Ctrl-j` which will exit insert mode. (This can be seamlessly expanded to `Ctrl-jk`, where `jk` is what most people are used to.)

<img width="293" alt="screen shot 2016-07-17 at 2 14 41 pm" src="https://cloud.githubusercontent.com/assets/236943/16903096/d5be03f2-4c28-11e6-8f79-ddeeeecb20f7.png">
