### PR TITLE
feat(babel): update babel to latest presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   },
   "homepage": "https://github.com/richgilbank/Scratch-JS",
   "dependencies": {
-    "babel-standalone": "6.7.7",
-    "babel-polyfill": "6.9.1",
+    "LiveScript": "https://github.com/gkz/LiveScript/archive/1.3.1.tar.gz",
+    "babel-polyfill": "^6.26.0",
+    "babel-standalone": "^6.26.0",
     "codemirror": "^5.10.0",
     "coffee-script": "https://github.com/jashkenas/coffeescript/archive/1.10.0.tar.gz",
-    "LiveScript": "https://github.com/gkz/LiveScript/archive/1.3.1.tar.gz",
     "traceur": "0.0.110"
   },
   "devDependencies": {

--- a/panel/scripts/transformers/babel.js
+++ b/panel/scripts/transformers/babel.js
@@ -7,9 +7,13 @@ function BabelTransformer() {
   this.opts = {
     filename: 'Babel',
     presets: [
-      'es2015',
-      'stage-0',
-      'stage-1'
+      'latest',
+      'stage-0' // includes stages 0, 1, 2, and 3
+    ],
+    plugins: [
+      // disabled from stage-2 preset until update, see:
+      // https://babeljs.io/docs/plugins/preset-stage-2/
+      'transform-decorators-legacy'
     ]
   };
 }


### PR DESCRIPTION
I'm updating the babel standalone (and polyfill) to their latest versions, and including decorators as well.

using the stage 0 preset includes all stages above it, and decorators were removed from stage 2 pending approval, which necessitates including the standalone legacy decorator plugin