### PR TITLE
Fix issue #97 Cannot type question mark.

### DIFF
--- a/panel/scripts/repl.js
+++ b/panel/scripts/repl.js
@@ -216,6 +216,11 @@ Repl.prototype.addEventListeners = function() {
       this.deliverContent(this.editor.getValue());
     }
   }.bind(this));
+  document.addEventListener('keydown', function(e) {
+    if(e.key === '?') {
+      e.stopPropagation();
+    }
+  }, true);
 
   this.DOM.resizeDivider.addEventListener('mousedown', debounce(this.onResizeMousedown.bind(this)), 200);
 


### PR DESCRIPTION
Chrome devtool opens settings panel by pressing `?` key. ([reference](https://developers.google.com/web/tools/chrome-devtools/shortcuts)).

When typing question mark in Scratch JS panel this `keydown` event would be captured by parent level panels. Therefore, the devtool settings panel opens instead of typing in question mark character.

To fix issue #97 , I added a new `keydown` event listener with the third parameter as `true`, to add the event handler in event capturing phase, and further to stop the event bubbling to the parent panel.