### PR TITLE
Changes Manifest v2 to v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "Scratch JS",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Write and execute ES6/ES2015 within DevTools!",
   "devtools_page": "es6-repl.html",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "icons": {
     "128": "art/128.png",
     "48": "art/48.png",
@@ -14,11 +14,15 @@
     "tabs"
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
   "web_accessible_resources": [
-    "node_modules/traceur/bin/traceur-runtime.js",
-    "node_modules/babel-polyfill/dist/polyfill.min.js"
+    {
+      "resources": [
+        "node_modules/traceur/bin/traceur-runtime.js",
+        "node_modules/babel-polyfill/dist/polyfill.min.js"
+      ],
+      "matches": ["<all_urls>"]
+    }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,11 @@
 {
   "name": "Scratch JS",
-  "version": "0.0.26",
+  "version": "0.0.25",
   "description": "Write and execute ES6/ES2015 within DevTools!",
   "devtools_page": "es6-repl.html",
   "manifest_version": 3,
+  "offline_enabled": true,
+  "minimum_chrome_version": "93",
   "icons": {
     "128": "art/128.png",
     "48": "art/48.png",
@@ -24,5 +26,6 @@
       ],
       "matches": ["<all_urls>"]
     }
-  ]
+  ],
+  "incognito": "split"
 }


### PR DESCRIPTION
Manifest V2 will stop working in June 2023. Hence updated with required changes and make Manifest V3.